### PR TITLE
Remove First Aid mentions from site

### DIFF
--- a/_authors/lia.md
+++ b/_authors/lia.md
@@ -1,7 +1,0 @@
----
-name: Lia
-core: first_aid
-role: First Aid Lead
----
-
-Lia was the First Aid Lead in 2022 and is excited to return for 2023!

--- a/_cores/first_aid.md
+++ b/_cores/first_aid.md
@@ -1,6 +1,0 @@
----
-name: first_aid
-short_name: First Aid
----
-
-The First Aid team is responsible for empowering Fireflies to be radically self reliant with their medical care at Firefly.


### PR DESCRIPTION
Lia stepped down as First Aid Core Lead + we decided to not have a separate First Aid Core in 2023.

This is a PR to remove Lia's bio + the First Aid Core description from the site.